### PR TITLE
msgpack5

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -10,7 +10,7 @@
 var uid2 = require('uid2');
 var redis = require('redis').createClient;
 // var msgpack = require('msgpack-js');
-var msgpack = require('msgpack');
+var msgpack = require('msgpack5');
 var Adapter = require('socket.io-adapter');
 var Emitter = require('events').EventEmitter;
 var debug = require('debug')('socket.io-redis');


### PR DESCRIPTION
# Use msgpack5 instead of msgpack. This makes symple work again with newer nodejs versions.(My version 6.2.2)
# before :

$npm install msgpack --save
$node server.js

module.js:356
  Module._extensions[extension](this, filename);
                               ^
Error: /home/shikch/Documents/nodejs/symple-server/node_modules/msgpack/build/Release/msgpackBinding.node: undefined symbol: node_module_register
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/shikch/Documents/nodejs/symple-server/node_modules/msgpack/lib/msgpack.js:6:14)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
#     at Module.require (module.js:364:17)
# now :

$npm install msgpack5 --save
$node server.js
Symple server listening on port 4500
